### PR TITLE
ADD: No HUD Heart animation (#3348)

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -913,6 +913,8 @@ void DrawEnhancementsMenu() {
                 UIWidgets::Tooltip("Disables grottos rotating with the camera. To be used in conjunction with mods that want to replace grottos with 3D objects.");
                 UIWidgets::PaddedEnhancementCheckbox("Invisible Bunny Hood", "gHideBunnyHood", true, false);
                 UIWidgets::Tooltip("Turns Bunny Hood invisible while still maintaining its effects.");
+                UIWidgets::PaddedEnhancementCheckbox("Disable HUD Heart animations", "gNoHUDHeartAnimation", true, false);
+                UIWidgets::Tooltip("Disables the beating animation of the hearts on the HUD.");
 
                 ImGui::EndMenu();
             }

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -601,13 +601,24 @@ void HealthMeter_Draw(PlayState* play) {
 
             {
                 Mtx* matrix = Graph_Alloc(gfxCtx, sizeof(Mtx));
-                Matrix_SetTranslateScaleMtx2(matrix, 
-                HeartsScale+(HeartsScale/3) - ((HeartsScale/3) * sp144), 
-                HeartsScale+(HeartsScale/3) - ((HeartsScale/3) * sp144),
-                HeartsScale+(HeartsScale/3) - ((HeartsScale/3) * sp144), 
-                -130+offsetX, //Pos X
-                (-94+offsetY) *-1, //Pos Y
-                0.0f);
+                
+                if (CVarGetInteger("gNoHUDHeartAnimation", 0)) {
+                    Matrix_SetTranslateScaleMtx2(matrix,
+                        HeartsScale,          // Scale X
+                        HeartsScale,          // Scale Y
+                        HeartsScale,          // Scale Z
+                        -130 + offsetX,       // Pos X
+                        (-94 + offsetY) * -1, // Pos Y
+                        0.0f);
+                } else {
+                    Matrix_SetTranslateScaleMtx2(matrix, HeartsScale + (HeartsScale / 3) - ((HeartsScale / 3) * sp144),
+                        HeartsScale + (HeartsScale / 3) - ((HeartsScale / 3) * sp144),
+                        HeartsScale + (HeartsScale / 3) - ((HeartsScale / 3) * sp144),
+                        -130 + offsetX,       // Pos X
+                        (-94 + offsetY) * -1, // Pos Y
+                        0.0f);
+                }
+
                 gSPMatrix(OVERLAY_DISP++, matrix, G_MTX_MODELVIEW | G_MTX_LOAD);
                 gSPVertex(OVERLAY_DISP++, sp154, 4, 0);
                 gSP1Quadrangle(OVERLAY_DISP++, 0, 2, 3, 1, 0);


### PR DESCRIPTION
* ADD: No HUD Heart Animation

I've seen this requested multiple times for modding purposes for the case of using "lifebars" instead of hearts

* TWEAK: Move it under the the mods

* REM: Whitespace

* REM: Whitespace2

* Tweak: Cvar Oppsie